### PR TITLE
fix confidential transaction execution gas

### DIFF
--- a/backend/eth/client_test.go
+++ b/backend/eth/client_test.go
@@ -238,26 +238,6 @@ func TestExecuteServiceOK(t *testing.T) {
 	}, res)
 }
 
-func TestExecuteServiceEstimateGasErr(t *testing.T) {
-	client, err := NewClient()
-	assert.Nil(t, err)
-
-	ethtest.ImplementMockWithOverwrite(client.client.(*ethtest.MockClient),
-		ethtest.MockMethods{
-			"EstimateGas": ethtest.MockMethod{
-				Arguments: []interface{}{mock.Anything, mock.Anything},
-				Return:    []interface{}{uint64(0), errors.New("error")},
-			},
-		})
-
-	_, err = client.ExecuteService(Context, 1, backend.ExecuteServiceRequest{
-		Address: "0x5d352cf2160f79CBF3554534cF25A4b42C43D502",
-		Data:    "0x0000000000000000000000000000000000000000",
-	})
-
-	assert.Equal(t, "[1002] error code InternalError with desc Internal Error. Please check the status of the service. with cause error", err.Error())
-}
-
 func TestExecuteServiceEmptyAddressErr(t *testing.T) {
 	client, err := NewClient()
 	assert.Nil(t, err)

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -105,28 +105,6 @@ func (s *ServicesTestSuite) TestExecuteServiceEmptyTransactionData() {
 	assert.Equal(s.T(), &rpc.Error{ErrorCode: 7002, Description: "Failed to verify AAD in transaction data."}, err)
 }
 
-func (s *ServicesTestSuite) TestExecuteServiceErrEstimateGas() {
-	ethtest.ImplementMockWithOverwrite(s.ethclient,
-		ethtest.MockMethods{
-			"EstimateGas": ethtest.MockMethod{
-				Arguments: []interface{}{mock.Anything, mock.Anything},
-				Return:    []interface{}{uint64(0), errors.New("error")},
-			},
-		})
-
-	ev, err := s.client.ExecuteServiceSync(context.TODO(), service.ExecuteServiceRequest{
-		Address: "0x0000000000000000000000000000000000000000",
-		Data:    "0x0000000000000000000000000000000000000000",
-	})
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), service.ErrorEvent{
-		ID: 0x0,
-		Cause: rpc.Error{
-			ErrorCode:   1002,
-			Description: "Internal Error. Please check the status of the service.",
-		}}, ev)
-}
-
 func (s *ServicesTestSuite) TestExecuteServiceOK() {
 	ethtest.ImplementMock(s.ethclient)
 

--- a/tx/owner.go
+++ b/tx/owner.go
@@ -199,6 +199,17 @@ func (e *WalletOwner) signTransaction(tx *types.Transaction) (*types.Transaction
 }
 
 func (e *WalletOwner) estimateGas(ctx context.Context, id uint64, address string, data []byte) (uint64, errors.Err) {
+	if len(address) == 0 {
+		return e.estimateGasNonConfidential(ctx, id, address, data)
+	}
+
+	// TODO(stan): parse the data to identify whether the contract is confidential.
+	// estimateGas does not work for confidential contracts so in that case we provide a reasonable
+	// amount of gas that may work
+	return 15177522, nil
+}
+
+func (e *WalletOwner) estimateGasNonConfidential(ctx context.Context, id uint64, address string, data []byte) (uint64, errors.Err) {
 	e.logger.Debug(ctx, "", log.MapFields{
 		"call_type": "EstimateGasAttempt",
 		"id":        id,


### PR DESCRIPTION
this should allow us for now to enable the e2e tests. 

I created this issue to handle this case more gracefully https://github.com/oasislabs/developer-gateway/issues/167, but for now we should at least to be able to enable e2e tests.