### PR TITLE
use contexts for auth

### DIFF
--- a/api/v0/event/handler.go
+++ b/api/v0/event/handler.go
@@ -35,7 +35,7 @@ type EventHandler struct {
 // Subscribe creates a new subscription for the client on the required
 // topics
 func (h EventHandler) Subscribe(ctx context.Context, v interface{}) (interface{}, error) {
-	authData := ctx.Value(auth.ContextAuthDataKey).(auth.AuthData)
+	session := ctx.Value(auth.Session{}).(string)
 	req := v.(*SubscribeRequest)
 
 	if len(req.Events) == 0 {
@@ -75,7 +75,7 @@ func (h EventHandler) Subscribe(ctx context.Context, v interface{}) (interface{}
 	id, err := h.client.Subscribe(ctx, backend.SubscribeRequest{
 		Event:      req.Events[0],
 		Address:    address,
-		SessionKey: authData.SessionKey,
+		SessionKey: session,
 		Topics:     query["topic"],
 	})
 	if err != nil {
@@ -93,12 +93,12 @@ func (h EventHandler) Subscribe(ctx context.Context, v interface{}) (interface{}
 // Unsubscribe destroys an existing client subscription and all the
 // resources associated with it
 func (h EventHandler) Unsubscribe(ctx context.Context, v interface{}) (interface{}, error) {
-	authData := ctx.Value(auth.ContextAuthDataKey).(auth.AuthData)
+	session := ctx.Value(auth.Session{}).(string)
 	req := v.(*UnsubscribeRequest)
 
 	err := h.client.Unsubscribe(ctx, backend.UnsubscribeRequest{
 		ID:         req.ID,
-		SessionKey: authData.SessionKey,
+		SessionKey: session,
 	})
 	if err != nil {
 		h.logger.Debug(ctx, "failed unsubscribe from events", log.MapFields{
@@ -114,7 +114,7 @@ func (h EventHandler) Unsubscribe(ctx context.Context, v interface{}) (interface
 // EventPoll allows the user to query for new events associated
 // with a specific subscription
 func (h EventHandler) PollEvent(ctx context.Context, v interface{}) (interface{}, error) {
-	authData := ctx.Value(auth.ContextAuthDataKey).(auth.AuthData)
+	session := ctx.Value(auth.Session{}).(string)
 	req := v.(*PollEventRequest)
 	if req.Count == 0 {
 		req.Count = 10
@@ -125,7 +125,7 @@ func (h EventHandler) PollEvent(ctx context.Context, v interface{}) (interface{}
 		Count:           req.Count,
 		Offset:          req.Offset,
 		ID:              req.ID,
-		SessionKey:      authData.SessionKey,
+		SessionKey:      session,
 	})
 	if err != nil {
 		h.logger.Debug(ctx, "failed to poll events from subscription", log.MapFields{

--- a/api/v0/event/handler_test.go
+++ b/api/v0/event/handler_test.go
@@ -78,10 +78,8 @@ func createEventHandler() EventHandler {
 }
 
 func TestSubscribeErrNoEvents(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -94,10 +92,8 @@ func TestSubscribeErrNoEvents(t *testing.T) {
 }
 
 func TestSubscribeErrTooManyEvents(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -110,10 +106,8 @@ func TestSubscribeErrTooManyEvents(t *testing.T) {
 }
 
 func TestSubscribeErrInvalidQueryParams(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -126,10 +120,8 @@ func TestSubscribeErrInvalidQueryParams(t *testing.T) {
 }
 
 func TestSubscribeErrReturn(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -147,10 +139,8 @@ func TestSubscribeErrReturn(t *testing.T) {
 }
 
 func TestSubscribeOKWithTopics(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -175,10 +165,8 @@ func TestSubscribeOKWithTopics(t *testing.T) {
 }
 
 func TestSubscribeOKNoTopic(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -203,10 +191,8 @@ func TestSubscribeOKNoTopic(t *testing.T) {
 }
 
 func TestUnsubscribeOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -222,10 +208,8 @@ func TestUnsubscribeOK(t *testing.T) {
 }
 
 func TestUnsubscribeErrReturn(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -240,10 +224,8 @@ func TestUnsubscribeErrReturn(t *testing.T) {
 }
 
 func TestPollEventOKEmpty(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -262,10 +244,8 @@ func TestPollEventOKEmpty(t *testing.T) {
 }
 
 func TestPollEventOKMultiple(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -302,10 +282,8 @@ func TestPollEventOKMultiple(t *testing.T) {
 }
 
 func TestPollEventErrUnknown(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 
@@ -322,10 +300,8 @@ func TestPollEventErrUnknown(t *testing.T) {
 }
 
 func TestPollEventErrReturn(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
 
 	handler := createEventHandler()
 

--- a/api/v0/service/handler_test.go
+++ b/api/v0/service/handler_test.go
@@ -105,10 +105,9 @@ func createServiceHandler() ServiceHandler {
 }
 
 func TestDeployServiceEmptyData(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("DeployServiceAsync",
@@ -124,9 +123,9 @@ func TestDeployServiceEmptyData(t *testing.T) {
 }
 
 func TestDeployServiceErr(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("DeployServiceAsync",
@@ -147,9 +146,9 @@ func TestDeployServiceErr(t *testing.T) {
 }
 
 func TestDeployServiceOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("DeployServiceAsync",
@@ -165,10 +164,9 @@ func TestDeployServiceOK(t *testing.T) {
 }
 
 func TestExecuteServiceEmptyData(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("ExecuteServiceAsync",
@@ -187,10 +185,9 @@ func TestExecuteServiceEmptyData(t *testing.T) {
 }
 
 func TestExecuteServiceEmptyAddress(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		ExpectedAAD: "",
-		SessionKey:  "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("ExecuteServiceAsync",
@@ -210,9 +207,9 @@ func TestExecuteServiceEmptyAddress(t *testing.T) {
 }
 
 func TestExecuteServiceErr(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("ExecuteServiceAsync",
@@ -235,9 +232,9 @@ func TestExecuteServiceErr(t *testing.T) {
 }
 
 func TestExecuteServiceOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("ExecuteServiceAsync",
@@ -257,9 +254,9 @@ func TestExecuteServiceOK(t *testing.T) {
 }
 
 func TestPollServiceErr(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("PollService",
@@ -285,9 +282,9 @@ func TestPollServiceErr(t *testing.T) {
 }
 
 func TestPollServiceDeployOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("PollService",
@@ -318,9 +315,9 @@ func TestPollServiceDeployOK(t *testing.T) {
 }
 
 func TestPollServiceExecuteOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("PollService",
@@ -352,9 +349,9 @@ func TestPollServiceExecuteOK(t *testing.T) {
 }
 
 func TestPollServiceErrorOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("PollService",
@@ -385,9 +382,9 @@ func TestPollServiceErrorOK(t *testing.T) {
 }
 
 func TestGetCodeEmptyAddress(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("GetCode",
@@ -408,9 +405,9 @@ func TestGetCodeEmptyAddress(t *testing.T) {
 }
 
 func TestGetCodeEmptyErr(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("GetCode",
@@ -431,9 +428,9 @@ func TestGetCodeEmptyErr(t *testing.T) {
 }
 
 func TestGetCodeEmptyOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("GetCode",
@@ -456,9 +453,9 @@ func TestGetCodeEmptyOK(t *testing.T) {
 }
 
 func TestGetPublicKeyEmptyAddress(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("GetPublicKey",
@@ -479,9 +476,9 @@ func TestGetPublicKeyEmptyAddress(t *testing.T) {
 }
 
 func TestGetPublicKeyEmptyErr(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("GetPublicKey",
@@ -502,9 +499,9 @@ func TestGetPublicKeyEmptyErr(t *testing.T) {
 }
 
 func TestGetPublicKeyEmptyOK(t *testing.T) {
-	ctx := context.WithValue(Context, auth.ContextAuthDataKey, auth.AuthData{
-		SessionKey: "sessionKey",
-	})
+	ctx := context.WithValue(Context, auth.AAD{}, "aad")
+	ctx = context.WithValue(ctx, auth.Session{}, "sessionKey")
+
 	handler := createServiceHandler()
 
 	handler.client.(*MockClient).On("GetPublicKey",

--- a/auth/core/auth.go
+++ b/auth/core/auth.go
@@ -1,16 +1,12 @@
 package core
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/oasislabs/developer-gateway/log"
 	"github.com/oasislabs/developer-gateway/stats"
 )
-
-type AuthData struct {
-	ExpectedAAD string
-	SessionKey  string
-}
 
 type AuthRequest struct {
 	API     string
@@ -27,11 +23,11 @@ type Auth interface {
 	// Authenticate the user from the http request. This should return:
 	// - the expected AAD
 	// - the authentication error
-	Authenticate(req *http.Request) (string, error)
+	Authenticate(req *http.Request) (*http.Request, error)
 
 	// Verify that a specific payload complies with
 	// the expected format and has the authentication data required
-	Verify(req AuthRequest, expected string) error
+	Verify(ctx context.Context, req AuthRequest) error
 
 	// Sets the logger for the authentication plugin.
 	SetLogger(log.Logger)
@@ -45,10 +41,10 @@ func (NilAuth) Name() string {
 func (NilAuth) Stats() stats.Metrics {
 	return nil
 }
-func (NilAuth) Authenticate(req *http.Request) (string, error) {
-	return "", nil
+func (NilAuth) Authenticate(req *http.Request) (*http.Request, error) {
+	return req, nil
 }
-func (NilAuth) Verify(req AuthRequest, expected string) error {
+func (NilAuth) Verify(ctx context.Context, req AuthRequest) error {
 	return nil
 }
 

--- a/auth/core/context.go
+++ b/auth/core/context.go
@@ -1,5 +1,0 @@
-package core
-
-const (
-	ContextAuthDataKey string = "authCoreContextAuthDataKey"
-)

--- a/auth/core/errors.go
+++ b/auth/core/errors.go
@@ -1,0 +1,16 @@
+package core
+
+import "strings"
+
+type MultiError struct {
+	Errors []error
+}
+
+func (e MultiError) Error() string {
+	var s []string
+	for _, err := range e.Errors {
+		s = append(s, err.Error())
+	}
+
+	return strings.Join(s, "; ")
+}

--- a/auth/insecure/insecure.go
+++ b/auth/insecure/insecure.go
@@ -1,6 +1,7 @@
 package insecure
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -26,16 +27,17 @@ func (a InsecureAuth) Stats() stats.Metrics {
 	return nil
 }
 
-func (a InsecureAuth) Authenticate(req *http.Request) (string, error) {
+func (a InsecureAuth) Authenticate(req *http.Request) (*http.Request, error) {
 	value := req.Header.Get(HeaderKey)
 	if len(value) == 0 {
-		return "", ErrDataTooShort
+		return req, ErrDataTooShort
 	}
 
-	return value, nil
+	ctx := context.WithValue(req.Context(), core.AAD{}, value)
+	return req.WithContext(ctx), nil
 }
 
-func (InsecureAuth) Verify(req core.AuthRequest, expectedAAD string) error {
+func (InsecureAuth) Verify(ctx context.Context, req core.AuthRequest) error {
 	if len(req.Data) == 0 {
 		return ErrDataTooShort
 	}

--- a/auth/oauth/google_test.go
+++ b/auth/oauth/google_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/oasislabs/developer-gateway/auth/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,9 +37,9 @@ func TestAuthenticateSuccess(t *testing.T) {
 	req.Header.Add(ID_TOKEN_KEY, string(jsonStr))
 
 	auth := NewGoogleOauth(&MockIDTokenVerifier{})
-	email, err := auth.Authenticate(req)
+	req, err = auth.Authenticate(req)
 	assert.Nil(t, err)
-	assert.Equal(t, "test@email.com", email)
+	assert.Equal(t, "test@email.com", req.Context().Value(core.AAD{}))
 }
 
 func TestAuthenticateUnverified(t *testing.T) {
@@ -54,8 +55,9 @@ func TestAuthenticateUnverified(t *testing.T) {
 	req.Header.Add(ID_TOKEN_KEY, string(jsonStr))
 
 	auth := NewGoogleOauth(&MockIDTokenVerifier{})
-	email, err := auth.Authenticate(req)
+	req, err = auth.Authenticate(req)
 	assert.NotNil(t, err)
+	assert.Equal(t, req, req)
 	assert.Equal(t, "Email is unverified", err.Error())
-	assert.Equal(t, "", email)
+	assert.Nil(t, req.Context().Value(core.AAD{}))
 }


### PR DESCRIPTION
 - Use contexts for authentication metadata to be able to pass data more freely
 - Allow multiple authentication schemes, and as soon as one succeeds use that one for data verification